### PR TITLE
Se agrega script para usar MySQL en Docker

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,0 +1,16 @@
+# Se descarga una version de MySQL 8.0 contenida en Debian 12 Bookworm 
+FROM mysql:8.0.37-bookworm
+
+# Se define el directorio dentro del contenedor donde se alojaran los scripts
+WORKDIR /docker-entrypoint-initdb.d
+
+# Se cargan los scripts de SQL de nuestro repositorio al contenedor
+ADD barro_db.sql /docker-entrypoint-initdb.d
+ADD test_data.sql /docker-entrypoint-initdb.d
+
+# Se definen las variables de entorno para crear la base de datos
+ENV MYSQL_ROOT_PASSWORD=pass1234 
+ENV MYSQL_DATABASE=barro_db
+
+# Se abre el puerto 3306 para poder conectarnos al contenedor
+EXPOSE 3306

--- a/database/Instrucciones.txt
+++ b/database/Instrucciones.txt
@@ -1,0 +1,49 @@
+### Creación del contenedor de MySQL en Docker
+Para levantar una base de datos en MySQL con un contenedor de Docker, realizar los siguientes pasos,
+aclarando que deben sustituir <nombre-imagen> y <nombre-contenedor> con nombres descriptivos de su 
+elección (yo sugiero "mysql-image" para la imagen y "barro-db-container" para el contenedor, pero 
+puede ser cualquiera) :
+
+1) Descargar e instalar Docker Desktop si aun no lo tienen (https://www.docker.com/products/docker-desktop/)
+
+2) Abrir una terminal y moverse al directorio actual (./proyecto-ch39/database)
+
+3) Crear una imagen de MySQL con los scripts de SQL a partir del dockerfile.yaml (script para Docker) 
+   utilizando el comando: 
+    - " docker build -t <nombre-imagen> . "
+
+4) Crear un contenedor a partir de la imagen creada con el comando: 
+    - " docker run --name <nombre-contenedor> -p 3306:3306 -d <nombre-imagen> "
+
+Realizados los pasos anteriores ya se tiene un contenedor con MySQL funcionando y listo para poder conectarse 
+y realizar distintas pruebas (Workbench, DBeaver, Spring Boot, etc.). 
+
+Dicho contenedor ya tiene cargados y ejecutados los scripts para crear la base de datos (barro_db.sql) y 
+llenar con datos de ejemplo (test_data.sql).
+
+
+### Comandos útiles para Docker
+Aquí hay unos comandos que les pueden servir para manejar los contenedores:
+
+* Verificar si un contenedor esta activo o ejecutándose : 
+    - " docker ps "
+
+* Obtener una lista de todas las imágenes de Docker en sus maquinas:
+    - "docker images"
+
+* Obtener lista de todos los contenedores creados (activos e inactivos):
+    - "docker ps -a"
+
+* Para obtener IP y Puerto del contenedor para realizar la conexión en Workbench u otros lados :
+    - IP: " docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' <nombre-contenedor> " 
+    
+    - Puerto: " docker inspect -f '{{range $p, $conf := .NetworkSettings.Ports}} {{$p}} -> {{(index $conf 0).HostPort}} {{end}}' <nombre-contenedor> "
+
+* Para detener o apagar el contenedor: 
+    - " docker stop <nombre-contenedor> "
+
+* Para iniciar o reactivar el contenedor: 
+    - "docker start <nombre-contenedor> "
+
+* Para borrar el contenedor: 
+    - "docker rm <nombre-contenedor> "

--- a/database/barro_db.sql
+++ b/database/barro_db.sql
@@ -1,6 +1,9 @@
 -- DROP DATABASE barro_db;
 
-CREATE DATABASE barro_db;
+CREATE DATABASE IF NOT EXISTS barro_db;
+
+-- Modificar base de datos existente para usar UTF-8
+ALTER DATABASE barro_db CHARACTER SET utf8 COLLATE utf8_general_ci;
 
 USE `barro_db`;
 


### PR DESCRIPTION
En el directorio "/database" se agregó Dockerfile (script de Docker) para crear un contenedor de MySQL con los scripts SQL de nuestro proyecto. La finalidad de este contenedor es facilitar el testing con la base de datos al no ser necesario la instalación y configuraciones de MySQL o cualquier otra base de datos en local, y por lo tanto, no depender tanto de las configuraciones de la máquina para permitir la portabilidad o funcionalidad multiplataforma. Ideal en este caso para pruebas rápidas con Backend (Spring Boot, Django, etc.) o la misma base de datos en Workbench.